### PR TITLE
Replace esclave with agent in firefox extension buildmonitor (fr)

### DIFF
--- a/src/main/resources/firefox/chrome/locale/fr-FR/buildmonitor.dtd
+++ b/src/main/resources/firefox/chrome/locale/fr-FR/buildmonitor.dtd
@@ -55,5 +55,5 @@
 <!ENTITY prefs.help.sound "Quand c'est activé, la notification sonore sera jouée à chaque échec de build.">
 <!ENTITY prefs.help.alert "Affiche une fenêtre d'alerte en bas à droite de votre bureau, indiquant les informations sur le build en échec.">
 <!ENTITY prefs.help.hidename "Si vous cachez le nom du flux, vous ne verrez plus que des icônes sur la barre de statut. Utile pour suivre de nombreux flux.">
-<!ENTITY prefs.help.executor "Quand c'est activé, les statuts des exécuteurs sur le maître et les esclaves seront également monitorés. Cette fonctionnalité n'est disponible que pour le flux de l'instance Jenkins (et non pour les flux spécifiques à chaque job).">
+<!ENTITY prefs.help.executor "Quand c'est activé, les statuts des exécuteurs sur le maître et les agents seront également monitorés. Cette fonctionnalité n'est disponible que pour le flux de l'instance Jenkins (et non pour les flux spécifiques à chaque job).">
 <!ENTITY prefs.help.networkusername "Les nom d'utilisateur et mot de passe sont utilisés pour une authentification d'accès basique sur les flux protégés par mot de passe. Laissez vide si vous n'avez pas besoin d'authentification. Notez que ce ne sont pas les mêmes valeurs que pour votre compte Jenkins.">


### PR DESCRIPTION
The word esclave appeared in the French documentation for the firefox extension buildmonitor; I changed it to agent (consistent with previous PRs).